### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ The goal is to provide a nicer user interface for using SQLite with Objective-C 
 
 ## Installation
 
-To install Mojo Database, simply drag the MojoDatabase directory into your XCode project and choose "copy files to destination" when prompted.
+To install Mojo Database, simply drag the MojoDatabase directory into your Xcode project and choose "copy files to destination" when prompted.
 
 ## Usage
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
